### PR TITLE
Remove imports ("use") and enclose code in ext_localconf.php in function

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,11 +3,7 @@
 defined('TYPO3_MODE') or die();
 
 (function () {
-    use TYPO3\CMS\Core\Utility\GeneralUtility;
-    use TYPO3\CMS\Core\Locking\LockFactory;
-    use B13\DistributedLocks\RedisLockingStrategy;
-
-    $lockFactory = GeneralUtility::makeInstance(LockFactory::class);
-    $lockFactory->addLockingStrategy(RedisLockingStrategy::class);
+    $lockFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Locking\LockFactory::class);
+    $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
 })();
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,9 +2,12 @@
 
 defined('TYPO3_MODE') or die();
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Locking\LockFactory;
-use B13\DistributedLocks\RedisLockingStrategy;
+(function () {
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+    use TYPO3\CMS\Core\Locking\LockFactory;
+    use B13\DistributedLocks\RedisLockingStrategy;
 
-$lockFactory = GeneralUtility::makeInstance(LockFactory::class);
-$lockFactory->addLockingStrategy(RedisLockingStrategy::class);
+    $lockFactory = GeneralUtility::makeInstance(LockFactory::class);
+    $lockFactory->addLockingStrategy(RedisLockingStrategy::class);
+})();
+


### PR DESCRIPTION
ext_localconf.php is concatenated into one file. If other extensions use
the same classes this may result in a fatal error.

Resolves: #4

> You must never use a use statement in the files global scope - that would make the cached script concept break and could conflict with other extensions.

see https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ConfigurationFiles/Index.html