### PR TITLE
Add priority option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Other options:
     'ttl' (numeric, default is 30sec)
     'port' (numeric, default is 6379)
     'authentication' (contains the password, necessary for secure authentication if required by redis)
+    'priority' (numeric, default is 95) - Set priority for this locking strategy. See LockingApi documentation.
 
 ## Future Development
 

--- a/src/RedisLockingStrategy.php
+++ b/src/RedisLockingStrategy.php
@@ -135,7 +135,14 @@ class RedisLockingStrategy implements LockingStrategyInterface
      */
     public static function getPriority()
     {
-        return 95;
+        $defaultPriority = 95;
+        $configuration = $GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis'] ?? null;
+        if (is_array($configuration) && isset($configuration['priority'])) {
+            $priority = (int)$configuration['priority'];
+        } else {
+            $priority = $defaultPriority;
+        }
+        return $priority;
     }
 
     /**


### PR DESCRIPTION
Add an configuration option to change the priority of this locking strategy.

I'm using this because it's the only way to turn off RedisLocking while the server is not available.