### PR TITLE
[FEATURE] Add option to disable the redis locking strategy altogether

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Other options:
     'password' (contains the password, necessary for secure authentication if required by redis)
     'priority' (numeric, default is 95) - Set priority for this locking strategy. See LockingApi documentation.
 
+## Disabling it in certain contextes
+
+If you have different `TYPO3_CONTEXT` or environments and you want to switch off the complete redis
+strategy (i.e. in your staging machine), you can set this in your LocalConfiguration / AdditionalConfiguration:
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis']['disabled'] = true;
+
 ## Future Development
 
 Should be switched to `symfony/lock` to allow distributed redis services and other lockers.

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,9 @@
 defined('TYPO3_MODE') or die();
 
 (function () {
-    $lockFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Locking\LockFactory::class);
-    $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
+    if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis']['disabled'])) {
+        $lockFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Locking\LockFactory::class);
+        $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
+    }
 })();
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,7 @@
 defined('TYPO3_MODE') or die();
 
 (function () {
-    if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis']['disabled'])) {
+    if (empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis']['disabled'])) {
         $lockFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Locking\LockFactory::class);
         $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
     }


### PR DESCRIPTION
Add an option to explicitly disable this extension in certain contextes. Default is to have it enabled (backwards compatible) so that if you do nothing you will still get the exceptions as usual (if the extension is installed but not configured or if redis PHP extension is not installed).

Resolves #14 