### PR TITLE
Add encryptionkey hash prefix to keys.

### DIFF
--- a/src/RedisLockingStrategy.php
+++ b/src/RedisLockingStrategy.php
@@ -89,9 +89,10 @@ class RedisLockingStrategy implements LockingStrategyInterface
             $this->ttl = (int)$configuration['ttl'];
         }
 
+        $redisKeyPrefix = sha1($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] . '_REDIS_LOCKING');
         $this->subject = $subject;
-        $this->name = sprintf('lock:name:%s', $subject);
-        $this->mutexName = sprintf('lock:mutex:%s', $subject);
+        $this->name = sprintf('%s:lock:name:%s', $redisKeyPrefix, $subject);
+        $this->mutexName = sprintf('%s:lock:mutex:%s', $redisKeyPrefix, $subject);
         $this->value = uniqid();
 
         $this->backend = $this->connectBackend($configuration);


### PR DESCRIPTION
This change allows multiple sites to use the same redis database, as long as the encryptionkey is unique (as it always should be).

The goals are:
- Host more sites on the same redis service (we have around 2600).
- Simplify administration, by not requiring the designation of database ids for each installation.

If you prefer, I can also re-submit this as a pull-request that just introduces an optional configurable prefix that is unset by default, which would make it a null change by default. But I believe this is the better approach, in terms of "just working", without introducing unneeded complexity, therefore I've submitted it in this form for nowl.