### PR TITLE
[TASK] Add RedisLockingStrategy to TYPO3_CONF_VARS-SYS-locking-strategies

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,8 +4,8 @@ defined('TYPO3_MODE') or die();
 
 (function () {
     if (empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis']['disabled'] ?? false)) {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['strategies'][\B13\DistributedLocks\RedisLockingStrategy::class] = [];
         $lockFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Locking\LockFactory::class);
         $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
     }
 })();
-


### PR DESCRIPTION
This change makes the `RedisLockingStrategy` show up in `$GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['strategies']` in the Backend configuration at /typo3/module/system/config

Fixes: https://github.com/b13/distributed-locks/issues/20