### PR TITLE
[!!!][TASK] Clean up code and raise PHP version compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": "^8.0",
     "ext-redis": "*",
-    "typo3/cms-core": "^11.0 || ^12.0"
+    "typo3/cms-core": "^11.0 || ^12.0 || ^13.0"
   },
   "extra": {
     "typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
   "keywords": ["TYPO3 CMS", "Redis", "Locking", "NFS"],
   "license": "GPL-2.0-or-later",
   "require": {
-    "php": "^7.0 | ^8.0",
+    "php": "^8.0",
     "ext-redis": "*",
-    "typo3/cms-core": "^8.7 || ^9.5 || ^10.0 || ^11.0 || ^12.0"
+    "typo3/cms-core": "^11.0 || ^12.0"
   },
   "extra": {
     "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,7 +4,7 @@ $EM_CONF[$_EXTKEY] = [
     'title' => 'Redis-based Locking',
     'description' => 'Adds a Locking Strategy for TYPO3 frontend page generation, useful on distributed systems with NFS.',
     'category' => 'fe',
-    'version' => '1.4.0',
+    'version' => '1.5.0',
     'state' => 'stable',
     'clearcacheonload' => true,
     'author' => 'Benni Mack',
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'b13 GmbH',
     'constraints' => [
         'depends' => [
-                'typo3' => '8.7.0-12.99.99',
+                'typo3' => '11.0.0-12.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,7 +4,7 @@ $EM_CONF[$_EXTKEY] = [
     'title' => 'Redis-based Locking',
     'description' => 'Adds a Locking Strategy for TYPO3 frontend page generation, useful on distributed systems with NFS.',
     'category' => 'fe',
-    'version' => '1.5.0',
+    'version' => '2.0.0',
     'state' => 'stable',
     'clearcacheonload' => true,
     'author' => 'Benni Mack',
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'b13 GmbH',
     'constraints' => [
         'depends' => [
-                'typo3' => '11.0.0-12.99.99',
+                'typo3' => '11.0.0-13.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,5 +11,4 @@ defined('TYPO3') or die();
 
     // Can be removed once TYPO3 v11 support is dropped
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Lowlevel\Controller\ConfigurationController::class]['modifyBlindedConfigurationOptions'][] = \B13\DistributedLocks\BlindedConfigurationOptionsHook::class;
-
 })();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3') or defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 (function () {
     if (empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['locking']['redis']['disabled'] ?? false)) {
@@ -9,6 +9,7 @@ defined('TYPO3') or defined('TYPO3_MODE') or die();
         $lockFactory->addLockingStrategy(\B13\DistributedLocks\RedisLockingStrategy::class);
     }
 
+    // Can be removed once TYPO3 v11 support is dropped
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Lowlevel\Controller\ConfigurationController::class]['modifyBlindedConfigurationOptions'][] = \B13\DistributedLocks\BlindedConfigurationOptionsHook::class;
 
 })();

--- a/src/BlindedConfigurationOptionsHook.php
+++ b/src/BlindedConfigurationOptionsHook.php
@@ -11,16 +11,24 @@ namespace B13\DistributedLocks;
  * of the License, or any later version.
  */
 
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent;
+
 /**
  * Hook for $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Lowlevel\Controller\ConfigurationController::class]['modifyBlindedConfigurationOptions']
  */
 class BlindedConfigurationOptionsHook
 {
+    #[AsEventListener]
+    public function __invoke(ModifyBlindedConfigurationOptionsEvent $event): void
+    {
+        $event->setBlindedConfigurationOptions(
+            $this->modifyBlindedConfigurationOptions($event->getBlindedConfigurationOptions())
+        );
+    }
+
     /**
      * Blind password in ConfigurationOptions
-     *
-     * @param array $blindedConfigurationOptions
-     * @return array
      */
     public function modifyBlindedConfigurationOptions(array $blindedConfigurationOptions): array
     {


### PR DESCRIPTION
Add native types, which now requires PHP 8.0.

For this reason, support for TYPO3 versions
lower than v11.0 is removed.